### PR TITLE
36 import cities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'sinatra', require: 'sinatra/base'
 gem 'pg'
 gem 'activerecord'
 gem 'sinatra-activerecord'
+gem 'ruby-progressbar'
 
 group :development, :test do
   gem 'shotgun'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    ruby-progressbar (1.8.1)
     shotgun (0.9.2)
       rack (>= 1.0)
     sinatra (1.4.7)
@@ -105,6 +106,7 @@ DEPENDENCIES
   rack-test
   rspec
   rspec-core
+  ruby-progressbar
   shotgun
   sinatra
   sinatra-activerecord

--- a/Rakefile
+++ b/Rakefile
@@ -3,3 +3,4 @@ Bundler.require
 
 require "sinatra/activerecord/rake"
 
+Dir.glob('lib/tasks/*.rake').each { |r| import r }

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -1,4 +1,4 @@
 class City < ActiveRecord::Base
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
 end

--- a/app/models/city_importer.rb
+++ b/app/models/city_importer.rb
@@ -2,16 +2,25 @@ require 'csv'
 
 class CityImporter
   attr_reader :filename,
-              :cities
+              :cities,
+              :number_of_lines
 
   def initialize(filename)
     @filename = filename
     @cities = []
+    @number_of_lines = `wc -l #{filename}`
   end
 
   def import
-    CSV.foreach(filename, headers: true) do |row|
-      City.create(name: row['city'])
+    bar = ProgressBar.create(title: "Cities", :total => number_of_lines.to_i)
+
+    City.transaction do
+      CSV.foreach(filename, headers: true) do |row|
+        City.create(name: row['city'])
+
+        bar.increment
+      end
+      bar.finish
     end
   end
 

--- a/app/models/city_importer.rb
+++ b/app/models/city_importer.rb
@@ -6,11 +6,11 @@ class CityImporter
 
   def initialize(filename)
     @filename = filename
-    @number_of_lines = `wc -l #{filename}`
+    @number_of_lines = `wc -l #{filename}`.to_i
   end
 
   def import
-    bar = ProgressBar.create(title: "Cities", :total => number_of_lines.to_i)
+    bar = ProgressBar.create(title: "Cities", total: number_of_lines)
 
     City.transaction do
       CSV.foreach(filename, headers: true) do |row|

--- a/app/models/city_importer.rb
+++ b/app/models/city_importer.rb
@@ -2,12 +2,10 @@ require 'csv'
 
 class CityImporter
   attr_reader :filename,
-              :cities,
               :number_of_lines
 
   def initialize(filename)
     @filename = filename
-    @cities = []
     @number_of_lines = `wc -l #{filename}`
   end
 

--- a/app/models/city_importer.rb
+++ b/app/models/city_importer.rb
@@ -1,0 +1,18 @@
+require 'csv'
+
+class CityImporter
+  attr_reader :filename,
+              :cities
+
+  def initialize(filename)
+    @filename = filename
+    @cities = []
+  end
+
+  def import
+    CSV.foreach(filename, headers: true) do |row|
+      City.create(name: row['city'])
+    end
+  end
+
+end

--- a/lib/tasks/import_cities.rake
+++ b/lib/tasks/import_cities.rake
@@ -1,0 +1,10 @@
+require './app/models/city_importer'
+require './app/models/city'
+
+desc "Import cities"
+namespace :import do
+  task :cities do
+    file = './db/csv/station.csv'
+    CityImporter.new(file).import
+  end
+end

--- a/spec/fixtures/bad_cities.csv
+++ b/spec/fixtures/bad_cities.csv
@@ -1,0 +1,1 @@
+id,name,lat,long,dock_count,city,installation_date

--- a/spec/fixtures/good_cities.csv
+++ b/spec/fixtures/good_cities.csv
@@ -1,0 +1,11 @@
+id,name,lat,long,dock_count,city,installation_date
+2,San Jose Diridon Caltrain Station,37.329732,-121.90178200000001,27,San Jose,8/6/2013
+3,San Jose Civic Center,37.330698,-121.888979,15,San Jose,8/5/2013
+4,Santa Clara at Almaden,37.333988,-121.894902,11,San Jose,8/6/2013
+5,Adobe on Almaden,37.331415,-121.8932,19,San Jose,8/5/2013
+22,Redwood City Caltrain Station,37.486078000000006,-122.23208899999999,25,Redwood City,8/15/2013
+23,San Mateo County Center,37.487615999999996,-122.229951,15,Redwood City,8/15/2013
+27,Mountain View City Hall,37.389218,-122.081896,15,Mountain View,8/16/2013
+33,Rengstorff Avenue / California Street,37.400240999999994,-122.099076,15,Mountain View,8/16/2013
+34,Palo Alto Caltrain Station,37.443988,-122.164759,23,Palo Alto,8/14/2013
+75,Mechanics Plaza (Market at Battery),37.7913,-122.399051,19,San Francisco,8/25/2013

--- a/spec/models/city_importer_spec.rb
+++ b/spec/models/city_importer_spec.rb
@@ -1,0 +1,22 @@
+require './spec/spec_helper'
+
+describe "City importer" do
+  let(:bad)  { './spec/fixtures/bad_cities.csv' }
+  let(:good) { './spec/fixtures/good_cities.csv' }
+
+  context "unsuccessful imports" do
+    it "does not import any cities" do
+      expect { 
+        CityImporter.new(bad).import
+      }.to change { City.count }.by(0)
+    end
+  end
+
+  context "successful imports" do
+    it "imports all the unique cities in the csv and saves them to the database" do
+      expect { 
+        CityImporter.new(good).import
+      }.to change { City.count }.by(5)
+    end
+  end
+end

--- a/spec/models/city_spec.rb
+++ b/spec/models/city_spec.rb
@@ -7,5 +7,12 @@ describe "City" do
 
       expect(city).not_to be_valid
     end
+
+    it "validates uniqueness of name" do
+      city_1 = City.create(name: "Chicago")
+      city_2 = City.new(name: "Chicago")
+
+      expect(city_2).not_to be_valid
+    end
   end
 end


### PR DESCRIPTION
closes #36 

I feel pretty good about this importer and the tests for it.  Hopefully this style continues to work on future imports, although I could imagine the larger files might require some tweaks to get them to import more quickly.  

How does this work?  From the command line...
$ rake -T  # => this will show the rake tasks
$ rake import:cities  # => this will import the cities, using the 'station.csv' file as the source

Note that the 'station.csv' file needs to be in your 'db/csv/' directory for this to work.

What do you think @akintner ?