### PR TITLE
35 link cities to stations

### DIFF
--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -1,4 +1,5 @@
 class City < ActiveRecord::Base
-
   validates :name, presence: true, uniqueness: true
+
+  has_many :stations
 end

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -2,4 +2,6 @@ class Station < ActiveRecord::Base
   validates :name, presence: true
   validates :dock_count, numericality: { only_integer: true }
   validates :installation_date, presence: true
+
+  belongs_to :city
 end

--- a/db/migrate/20161204174413_add_city_id_to_stations.rb
+++ b/db/migrate/20161204174413_add_city_id_to_stations.rb
@@ -1,0 +1,5 @@
+class AddCityIdToStations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :stations, :city_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161203211814) do
+ActiveRecord::Schema.define(version: 20161204174413) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 20161203211814) do
     t.date     "installation_date"
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
+    t.integer  "city_id"
   end
 
 end

--- a/spec/models/city_spec.rb
+++ b/spec/models/city_spec.rb
@@ -15,4 +15,22 @@ describe "City" do
       expect(city_2).not_to be_valid
     end
   end
+
+  context "relationships" do
+    let(:today)     { Date.today }
+    let(:yesterday) { Date.yesterday }
+
+    it "has many stations" do
+      station_1 = Station.create(name: "Downtown", dock_count: 12, installation_date: today)
+      station_2 = Station.create(name: "Uptown", dock_count: 22, installation_date: yesterday)
+      city = City.create(name: "Chicago")
+
+      city.stations << station_1
+      city.stations << station_2
+
+      expect(city.stations.count). to eq(2)
+      expect(city.stations.include?(station_1)).to be true
+      expect(city.stations.include?(station_2)).to be true
+    end
+  end
 end

--- a/spec/models/station_spec.rb
+++ b/spec/models/station_spec.rb
@@ -31,4 +31,14 @@ describe "Station" do
       expect(station).not_to be_valid
     end
   end
+
+  context "relationships" do
+    it "belongs to a city" do
+      city = City.create(name: "Chicago")
+      station = Station.create(name: "Downtown", dock_count: 12, installation_date: Date.today, city: city)
+
+      expect(station.city.name).to eq("Chicago")
+    end
+  end
+
 end


### PR DESCRIPTION
closes #35 

@akintner this is just the spec/model/db migration for 'a city has many stations' and the reverse of that 'a station belongs to a city'.  Please take a look and let me know what you think.  If it looks good, merge away!  (and don't forget to rake db:migrate your database and rake db:test:load to get the tests to pass)